### PR TITLE
新增HCOSP.py和SATCM.py;实现TERMINAL只输出logging.warning的内容；修复es连接时用户名读取错误问题

### DIFF
--- a/webSpider/pipelines.py
+++ b/webSpider/pipelines.py
@@ -23,17 +23,17 @@ class ElasticSearchPipeline:
         load_dotenv()
         logging.debug("print config value: %s", os.environ)
 
-        USERNAME = os.environ.get("USERNAME", False)
+        NAME = os.environ.get("NAME", False)
         PASSWORD = os.environ.get("PASSWORD", False)
         URL = os.environ.get("URL", False)
 
-        if not (USERNAME and PASSWORD and URL):
+        if not (NAME and PASSWORD and URL):
             self.es_connected = False
         else:
             # 详情参考官方文档 https://elasticsearch-py.readthedocs.io/en/7.x/
             try:
                 self.es = Elasticsearch(
-                    ["http://{}:{}@{}/".format(USERNAME, PASSWORD, URL)]
+                    ["http://{}:{}@{}/".format(NAME, PASSWORD, URL)]
                 )
                 logging.debug("ElasticSearch connected")
 

--- a/webSpider/settings.py
+++ b/webSpider/settings.py
@@ -13,6 +13,7 @@ BOT_NAME = "webSpider"
 SPIDER_MODULES = ["webSpider.spiders"]
 NEWSPIDER_MODULE = "webSpider.spiders"
 
+LOG_LEVEL= "WARNING"
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.128 Safari/537.36 Edg/89.0.774.77"

--- a/webSpider/spiders/HCOSP.py
+++ b/webSpider/spiders/HCOSP.py
@@ -1,0 +1,87 @@
+#author @hyl
+import scrapy
+from webSpider.items import ElasticSearchItem
+import re
+from lxml import etree
+import requests
+from datetime import date
+from time import strftime
+import logging
+from w3lib.html import remove_tags
+from scrapy.utils.log import configure_logging
+class QuoteSpider(scrapy.Spider):
+    name="HCOSP"
+    allowed_domains=["wjw.shanxi.gov.cn"]
+
+    def __init__(self):
+        #loggingRoot = False if (hasattr(self, "mode")) else True
+        #configure_logging(install_root_handler=loggingRoot)
+        current_time = strftime("%Y-%m-%dT%H:%M:%S%z")
+        logging.basicConfig(
+            format='%(asctime)s %(filename)s %(levelname)s %(message)s',
+            filename=f"./logs/scrapy_{current_time}.log", 
+            level=logging.WARNING,
+        )# ISO 8601 Timestamp format
+    
+    def start_requests(self):
+        
+        headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36 Edg/93.0.961.52"}
+        url="http://wjw.shanxi.gov.cn/zyygljl01/index.hrh"
+        res=requests.get(url=url,headers=headers)
+        tree=etree.HTML(res.text)
+        page=tree.xpath("//div[@class='fenye']/div/text()")[0]
+        page=re.search(r"(/\d{1,2})",page).group(0)[1:3]
+        
+        for i in range(1,int(page)+1):
+            url="http://wjw.shanxi.gov.cn/zyygljl01/index_{}.hrh".format(i)
+            logging.warning("start to get----{}".format(url))
+            yield scrapy.Request(url=url,callback=self.parse)
+    
+    def parse(self, response):
+        url_list=response.xpath("//div[@class='demo-right']/ul/li")
+        for i in url_list:
+            url_article=i.xpath("./a/@href").extract_first()
+            if url_article!=None:
+                yield scrapy.Request(url=url_article,callback=self.content_url)
+                
+    def content_url(self,response):
+        item=ElasticSearchItem()
+        try:
+            publishingDate=response.xpath("//div[@class='artxx']/text()").extract_first()
+            
+            item["publishingDate"] = re.search(r"(\d{4}-\d{1,2}-\d{1,2}\s\d{1,2}:\d{1,2}:\d{1,2})",publishingDate).group(0)
+
+            item['urlSource']=response.url
+
+            article=response.css("div.ze-art").get()
+            item["article"] = article
+            plaintext=re.sub(r"\s(\s)+", " ", remove_tags(article))
+            item["plaintext"] = plaintext
+
+            title=response.xpath("//h3/text()").extract_first()
+            item['title']=title
+            
+            item["source"] = "山西省卫生健康委员会"
+
+            today = date.today()
+            d1 = today.strftime("%Y-%m-%d")
+            item["scrapyDate"] = d1
+
+            attachment = []
+            attachment_list_a = response.xpath("//div[@class='ze-art']/p/a")
+            if attachment_list_a!=None:
+                for i in attachment_list_a:
+                    response.urljoin
+                    mark=i.xpath("./text()").extract_first()
+                    link=response.urljoin(i.xpath("./@href"))
+                    attachment.append({"mark": mark, "link": link})
+                item["attachment"] = attachment
+            logging.warning("scrapy url----{}".format(response.url))
+            yield item
+        except:
+             logging.error("Erro url----{}".format(response.url)) 
+        
+            
+        
+        
+        

--- a/webSpider/spiders/SATCM.py
+++ b/webSpider/spiders/SATCM.py
@@ -1,0 +1,116 @@
+#author @hyl
+from urllib.parse import urljoin
+import scrapy
+from webSpider.items import ElasticSearchItem
+import re
+from datetime import date
+from time import strftime
+import logging
+from w3lib.html import remove_tags
+from scrapy.utils.log import configure_logging
+
+class QuoteSpider(scrapy.Spider):
+    name="SATCM"
+    allowed_domains=["atcm.shaanxi.gov.cn"]
+    
+    def __init__(self):
+        #loggingRoot = False if (hasattr(self, "mode")) else True
+        #configure_logging(install_root_handler=loggingRoot)
+
+        #！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！BUG 无法创建log
+        current_time = strftime("%Y-%m-%dT%H:%M:%S%z")
+        logging.basicConfig(
+            format="%(asctime)s %(levelname)s:%(message)s",
+            filename=f"./logs/scrapy_{current_time}.log",
+            level=logging.WARNING,
+        )  # ISO 8601 Timestamp format  
+    
+    def start_requests(self):
+        urls={
+            True:["http://atcm.shaanxi.gov.cn/bsfw/xzzq/","http://atcm.shaanxi.gov.cn/sy/dtyw/index.html",
+                  "http://atcm.shaanxi.gov.cn/zfxxgk/zcjd/","http://atcm.shaanxi.gov.cn/zfxxgk/zfxxgknb/",
+                  "http://atcm.shaanxi.gov.cn/zfxxgk/zfxxgkzn/","http://atcm.shaanxi.gov.cn/zfxxgk/zfxxgkzd/"
+                  ],
+            False:["http://atcm.shaanxi.gov.cn/bsfw/xzzq/"]
+        }#[hasattr(self, "mode") and self.mode == "prod"]
+
+        for i in range(6):
+            #logging.warning("start to get----{}".format(urls[True][i]))
+            if i==0:
+                yield scrapy.Request(url=urls[True][i],callback=self.parse)#下载专区
+            elif i==1:
+                yield scrapy.Request(url=urls[True][i],callback=self.parse)#动态要闻
+                for nub in range(1,50):#!！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！！!!!!!!!!!!!BUG 页数不能自动获取
+                    url_page="http://atcm.shaanxi.gov.cn/sy/dtyw/index_{}".format(nub)+".html"
+                    yield scrapy.Request(url=url_page,callback=self.parse)
+            elif i==2:
+                yield scrapy.Request(url=urls[True][i],callback=self.parse)#政策解读
+            elif i==3:
+                yield scrapy.Request(url=urls[True][i],callback=self.parse)#政府信息公开年报
+            elif i==4:
+                yield scrapy.Request(url=urls[True][i],callback=self.content_pattern2)#政府信息公开指南(无二级链接)
+            elif i==5:
+                yield scrapy.Request(url=urls[True][i],callback=self.content_pattern2)#政府信息公开制度(无二级链接)
+            
+    def parse(self, response):
+        if len(response.url)>=45:
+            url_list=response.xpath("//li[@class='clearfix']")
+            for i in url_list:
+                url=response.urljoin(i.xpath("./a/@href").extract_first())
+                if url!=None:
+                    yield scrapy.Request(url=url,callback=self.content_pattern1)
+        else:
+            url_list=response.xpath("//a[@class='f-otw']")
+            for i in url_list:
+                url_origin=response.urljoin(i.xpath("./@href").extract_first())
+                if url_list!=None:
+                    yield scrapy.Request(url=url_origin,callback=self.content_pattern1) 
+
+    #解析网页
+    def content_pattern1(self,response):
+        item=ElasticSearchItem()
+        logging.warning("scrapy url----{}".format(response.url))
+        publishingDate=response.xpath("//span[@class='con']/text()").extract_first()
+        item["publishingDate"] = publishingDate
+        
+        article=response.css(".view").get()
+        item["article"] = article
+        plaintext=re.sub(r"\s(\s)+", " ", remove_tags(article))
+        item["plaintext"] = plaintext
+        
+        title=response.xpath("//h1/text()").extract_first()
+        item['title']=title
+        
+        item['urlSource']=response.url
+        item["source"] = "陕西省中医药管理局"
+
+        today = date.today()
+        d1 = today.strftime("%Y-%m-%d")
+        item["scrapyDate"] = d1
+
+        attachment = []
+        a_list=re.findall(r'<a.*?do.\w{0,1}.*?a>',response.text)
+        for i in a_list:
+            link=response.url[:44]+re.findall(r'P.*?do.\w{0,1}',i)[0]
+            mark=re.findall(r'>.*?<',i)[0]
+            if len(mark)<=2:
+                continue
+            attachment.append({"mark": mark[1:-1], "link": link})
+        item["attachment"] = attachment
+        yield item
+
+    def content_pattern2(self, response):
+        item=ElasticSearchItem()
+        logging.warning("scrapy url----{}".format(response.url))
+        item["source"] = "陕西省中医药管理局"
+        title=response.xpath("//h1[@class='tit']/text()").extract_first()
+        item['title']=title
+        
+        article=response.css(".con-box").get()
+        item["article"] = article
+        plaintext=re.sub(r"\s(\s)+", " ", remove_tags(article))
+        item["plaintext"] = plaintext
+        yield item
+    
+
+        


### PR DESCRIPTION
pipelines.py 连接数据库时用户名的变量不能使用USERNAME，会与本地计算机的名称冲突；修改为NAME即可。

setting.py  新增LOG_LEVEL='WARING'，使运行scrapy crawl xxxx.py 时TERMINAL只输出logging.warning 的内容。

SATCM.py 存在BUG：动态要闻的总页码数无法获取。

SATCM.py  爬取的是urls[True]的url，
即屏蔽了  [hasattr(self, "mode") and self.mode == "prod"]

存在的问题: logging.basicConfig 运行scrapy crawl xxxx.py 时无法产生log文件。

crawling_catalog.md 陕西中医药管理局 爬虫内容的模板 有调整次序。